### PR TITLE
Disable favorite auto removal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ const favorites: JupyterFrontEndPlugin<void> = {
         const favorite = args.favorite as IFavorites.Favorite;
         const path = favorite.path === '' ? '/' : favorite.path;
         await commands.execute('filebrowser:open-path', { path });
-        favoritesManager.removeFavoriteIfInvalid(favorite);
+        //favoritesManager.removeFavoriteIfInvalid(favorite);
       },
       label: (args) => {
         const favorite = args.favorite as IFavorites.Favorite;


### PR DESCRIPTION
Comment out the favorite removal if the path is unavailable/unreachable.  This looks like it was meant for dead link cleanup, but has a side effect of removing valid links that could be temporarily unreachable.